### PR TITLE
chore: reduce pull eagerness using minimumReleaseAge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,8 +14,9 @@
       ]
     },
     {
+      "automerge": true,
       "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true
+      "minimumReleaseAge": "3 days"
     }
   ]
 }


### PR DESCRIPTION
Getting 404s on relevant releases; adding minimumReleaseAge should slow us down a bit