### PR TITLE
renovate/reconfigure

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigestsToSemver"
   ],
   "labels": [
     "dependencies"


### PR DESCRIPTION
Add `helpers:pinGitHubActionDigestsToSemver` to renovate's extends list.

This ensures GitHub Action references are pinned to semver-compatible digests.